### PR TITLE
Bytt til DATABASE_JDBC_URL

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -8,9 +8,7 @@ spring:
   flyway:
     enabled: true
   datasource:
-    url: "jdbc:postgresql://${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_DATABASE}?reWriteBatchedInserts=true"
-    username: ${DATABASE_USERNAME}
-    password: ${DATABASE_PASSWORD}
+    url: "${DATABASE_JDBC_URL}&reWriteBatchedInserts=true"
     hikari:
       minimum-idle: 1
       maximum-pool-size: 5


### PR DESCRIPTION
Fra Slack:

Feilen ser ut til å komme av at dere prøver å koble til uten å oppgi nødvendige ssl sertifikater, som ble påkrevd da vi introduserte private IP'er på sqlinstansene. Det skal gå av seg selv hvis du bruker ${DB_URL} eller ${DB_JDBC_URL}, men hvis du bygger connection string selv må du huske å få med ssl parametrene.
